### PR TITLE
eval tag-to-version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.cvillecsteele/lein-git-version "1.2.7"
+(defproject org.clojars.cvillecsteele/lein-git-version "1.2.8"
   :description "Use git for project versions"
   :url "https://github.com/cvillecsteele/lein-git-version"
   :license {:name "Eclipse Public License"

--- a/src/leiningen/git_version.clj
+++ b/src/leiningen/git_version.clj
@@ -18,12 +18,13 @@
    :root-ns nil
    :assoc-in-keys [[:version]]
    :filename "version.clj"
-   :tag-to-version #(apply str (rest %))})
+   :tag-to-version `#(apply str (rest %))})
 
 (defn get-git-version
   [{:keys [version-cmd tag-to-version] :as config}]
-  (let [cmd (clojure.string/split version-cmd #" ")]
-    (tag-to-version (clojure.string/trim (:out (apply sh cmd))))))
+  (let [cmd (clojure.string/split version-cmd #" ")
+        out (clojure.string/trim (:out (apply sh cmd)))]
+    (eval `(~tag-to-version ~out))))
 
 (defn get-git-ref
   [{:keys [ref-cmd] :as config}]


### PR DESCRIPTION
Setting :tag-to-version in project.clj resulted in this error:

java.lang.ClassCastException: clojure.lang.PersistentList cannot be
cast to clojure.lang.IFn